### PR TITLE
Add Migration Tool Option for golang-migrate

### DIFF
--- a/cmd_make.go
+++ b/cmd_make.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/schemalex/schemalex/diff"
 	"github.com/urfave/cli/v2"
+)
+
+const (
+	SQLMigrate    = "sql-migrate"
+	GolangMigrate = "golang-migrate"
 )
 
 func cmdMake(c *cli.Context) error {
@@ -19,28 +25,83 @@ func cmdMake(c *cli.Context) error {
 		return err
 	}
 
+	in := migrateInput{
+		name:    newName,
+		baseDir: baseDir,
+		history: last,
+		lastSQL: lastSql,
+		mainSQL: mainSql,
+	}
+
+	migrationTool := c.String("tool")
+	switch migrationTool {
+	case SQLMigrate:
+		return makeMigrationFileSqlMigrate(in)
+	case GolangMigrate:
+		return makeMigrationFileGoMigrate(in)
+	default: // default use sql-migrate
+		return makeMigrationFileSqlMigrate(in)
+	}
+}
+
+type migrateInput struct {
+	name    string
+	baseDir string
+
+	history *history
+	lastSQL []byte
+	mainSQL []byte
+}
+
+func makeMigrationFileSqlMigrate(in migrateInput) error {
+	h := &history{
+		Id:   in.history.Id + 1,
+		Name: in.name,
+	}
 	migrationSql := &bytes.Buffer{}
 	migrationSql.Write([]byte("-- +migrate Up\nSET FOREIGN_KEY_CHECKS = 0;\n"))
-	err = diff.Strings(migrationSql, string(lastSql), string(mainSql))
+	err := diff.Strings(migrationSql, string(in.lastSQL), string(in.mainSQL))
 	if err != nil {
 		return err
 	}
 
 	migrationSql.Write([]byte("\nSET FOREIGN_KEY_CHECKS = 1;\n\n\n-- +migrate Down\nSET FOREIGN_KEY_CHECKS = 0;\n"))
-	err = diff.Strings(migrationSql, string(mainSql), string(lastSql))
+	err = diff.Strings(migrationSql, string(in.mainSQL), string(in.lastSQL))
 	if err != nil {
 		return err
 	}
 
 	migrationSql.Write([]byte("\nSET FOREIGN_KEY_CHECKS = 1;\n"))
-	newHistory := &history{
-		Id:   last.Id + 1,
-		Name: newName,
+	if err := putMigrationFile(in.baseDir, fmt.Sprintf("%s.sql", h.String()), migrationSql.Bytes()); err != nil {
+		return err
 	}
-	err = put(baseDir, newHistory, migrationSql.Bytes(), mainSql)
+	return putHistory(in.baseDir, h, in.mainSQL)
+}
+
+func makeMigrationFileGoMigrate(in migrateInput) error {
+	h := &history{
+		Id:   in.history.Id + 1,
+		Name: in.name,
+	}
+	migrationSql := &bytes.Buffer{}
+	err := diff.Strings(migrationSql, string(in.lastSQL), string(in.mainSQL))
+	if err != nil {
+		return err
+	}
+	err = putMigrationFile(in.baseDir, fmt.Sprintf("%s.up.sql", h.String()), migrationSql.Bytes())
 	if err != nil {
 		return err
 	}
 
-	return nil
+	err = diff.Strings(migrationSql, string(in.mainSQL), string(in.lastSQL))
+	if err != nil {
+		return err
+	}
+
+	err = putMigrationFile(in.baseDir, fmt.Sprintf("%s.down.sql", h.String()), migrationSql.Bytes())
+	if err != nil {
+		return err
+	}
+
+	return putHistory(in.baseDir, h, in.mainSQL)
 }

--- a/fs.go
+++ b/fs.go
@@ -19,18 +19,13 @@ func readFileAll(path string) ([]byte, error) {
 	return buff, err
 }
 
-func put(baseDir string, history *history, migration, full []byte) error {
+func putHistory(baseDir string, history *history, full []byte) error {
+	return os.WriteFile(filepath.Join(historiesBase(baseDir), history.SqlFilename()), full, os.ModePerm)
 
-	err := os.WriteFile(filepath.Join(historiesBase(baseDir), history.SqlFilename()), full, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	err = os.WriteFile(filepath.Join(migrationsBase(baseDir), history.SqlFilename()), migration, os.ModePerm)
-	if err != nil {
-		return err
-	}
+}
 
-	return nil
+func putMigrationFile(baseDir string, sqlFileName string, migration []byte) error {
+	return os.WriteFile(filepath.Join(migrationsBase(baseDir), sqlFileName), migration, os.ModePerm)
 }
 
 func historiesBase(baseDir string) string {

--- a/main.go
+++ b/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
-	"github.com/joho/godotenv"
-	"github.com/urfave/cli/v2"
 	"log"
 	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+	"github.com/urfave/cli/v2"
 )
 
 func main() {
@@ -35,8 +37,10 @@ func main() {
 					Required: true,
 				},
 				&cli.StringFlag{
-					Name:     "tool",
-					Required: false,
+					Name:        "tool",
+					Required:    false,
+					DefaultText: "sql-migrate",
+					Usage:       "supported " + strings.Join([]string{SQLMigrate, GolangMigrate}, ", "),
 				},
 			},
 			Action: cmdMake,

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@ func main() {
 					Name:     "name",
 					Required: true,
 				},
+				&cli.StringFlag{
+					Name:     "tool",
+					Required: false,
+				},
 			},
 			Action: cmdMake,
 		},


### PR DESCRIPTION
This tool only has a specification to generate a migration file for `rubenv/sql-migrate`, but I added an option to output a migration file for other migration tools( because we use `golang-migrate/migrate`

- for backward compatibility, and if there is no option, output for `rubenv/sql-migrate`
```
$ go run . make --name update
$ find schema/migrations
schema/migrations/000001_update.sql
$ cat schema/migrations/000001_update.sql
-- +migrate Up
SET FOREIGN_KEY_CHECKS = 0;
CREATE TABLE `article` (
`id` BIGINT (20) NOT NULL AUTO_INCREMENT,
`content` TEXT NOT NULL,
`title` VARCHAR (100) NOT NULL,
`original_url` VARCHAR (255) NOT NULL,
`category` VARCHAR (255) NOT NULL,
`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
PRIMARY KEY (`id`)
);
SET FOREIGN_KEY_CHECKS = 1;


-- +migrate Down
SET FOREIGN_KEY_CHECKS = 0;
DROP TABLE `article`;
SET FOREIGN_KEY_CHECKS = 1;
```

- it can generate a file for golang-migrate with the `--tool` option
```
$ go run . make --name update --tool golang-migrate
$ find schema/migrations
schema/migrations/000001_update.up.sql
schema/migrations/000001_update.down.sql
$ cat schema/migrations/000001_update.up.sql
CREATE TABLE `article` (
`id` BIGINT (20) NOT NULL AUTO_INCREMENT,
`content` TEXT NOT NULL,
`title` VARCHAR (100) NOT NULL,
`original_url` VARCHAR (255) NOT NULL,
`category` VARCHAR (255) NOT NULL,
`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
PRIMARY KEY (`id`)
);

$ cat schema/migrations/000001_update.down.sql
CREATE TABLE `article` (
`id` BIGINT (20) NOT NULL AUTO_INCREMENT,
`content` TEXT NOT NULL,
`title` VARCHAR (100) NOT NULL,
`original_url` VARCHAR (255) NOT NULL,
`category` VARCHAR (255) NOT NULL,
`created_at` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
PRIMARY KEY (`id`)
);DROP TABLE `article`;
```
